### PR TITLE
Fix bug in compiler handling of dependency imports

### DIFF
--- a/src/components/Playground/Output/Transform/index.tsx
+++ b/src/components/Playground/Output/Transform/index.tsx
@@ -2,7 +2,7 @@ import MonacoEditor from '@monaco-editor/react'
 import { Loader } from 'esbuild-wasm'
 import '@/components/Playground/Output/Transform/transform.scss'
 import { IFile, ITheme } from '@/components/Playground/shared'
-import { cssToJs, jsonToJs, addReactImport } from '@/components/Playground/files'
+import { cssToJs, jsonToJs } from '@/components/Playground/files'
 import Compiler from '@/components/Playground/compiler'
 import { MonacoEditorConfig } from '@/components/Playground/CodeEditor/Editor/monacoConfig'
 
@@ -16,12 +16,7 @@ const Transform = ({ file, theme }: OutputProps) => {
     const [errorMsg, setErrorMsg] = useState('')
 
     const compile = (code: string, loader: Loader) => {
-        let _code = code
-        if (['jsx', 'tsx'].includes(loader)) {
-            _code = addReactImport(code)
-        }
-
-        Compiler?.transform(_code, loader)
+        Compiler?.transform(code, loader)
             .then((value) => {
                 setCompiledCode(value.code)
                 setErrorMsg('')

--- a/src/components/Playground/files.ts
+++ b/src/components/Playground/files.ts
@@ -106,7 +106,7 @@ export const cssToJs = (file: IFile) => {
 }
 
 export const addReactImport = (code: string) => {
-    if (!/import\s+React/g.test(code)) {
+    if (!/^\s*import\s+React\s+/g.test(code)) {
         return `import React from 'react';\n${code}`
     }
     return code


### PR DESCRIPTION
By default, when importing UI component libraries such as MUI, React is imported again, resulting in multiple instances of React, which in turn causes issues with React-related functionality. Fixed by automatically externalizing existing dependencies during the dependency import process.